### PR TITLE
Issue10 generation skipping some characters

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -328,33 +328,33 @@ fn trigger_action(
                     while let Some(response) = response_stream.next().await {
                         whole_buffer.push(response.clone());
                         delta_buffer.push(response);
-                    
+
                         // No need to clone delta_buffer as we're going to clear it anyway.
                         let delta_output = delta_buffer.join("");
                         delta_buffer.clear();
-                    
+
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
                                 // Split the output on new lines and send each part followed by an 'Enter' keypress.
                                 for (index, line) in delta_output.split('\n').enumerate() {
                                     if index != 0 {
                                         // Simulate pressing the 'Enter' key.
-                                        enigo.key(Key::Return, Direction::Click);  
+                                        enigo.key(Key::Return, Direction::Click);
                                     }
 
                                     enigo.text(line);
                                 }
                             }
                         }
-                    
+
                         // Exit loop if child process has finished or exit flag is set
                         if exit_flag_thread.load(Ordering::SeqCst) {
                             did_exit = true;
                             break;
                         }
-                    }   
+                    }
                 }
-                
+
                 let mut should_continue = false;
                 if !did_exit {
                     let delta_output = delta_buffer.join("");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -335,12 +335,7 @@ fn trigger_action(
 
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
-                                // Split the output on new lines and send each part followed by an 'Enter' keypress.
-                                for step in trigger.next_steps.clone() {
-                                    if let Step::StreamTextToScreen = step {
-                                        enigo.text(&delta_output).expect("Failed to type out text");
-                                    }
-                                }
+                                enigo.text(&delta_output).expect("Failed to type out text");
                             }
                         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,13 +46,18 @@ fn main() {
     let trigger_flag = Arc::new(AtomicBool::new(false));
     let trigger_index = Arc::new(AtomicUsize::new(0));
 
-    let trigger_flag_clone = trigger_flag.clone();
-
     let old_clipboard = Arc::new(Mutex::new(String::new()));
 
-    let trigger_flag_listen_clone = trigger_flag.clone();
-    let exit_flag_listen_clone = exit_flag.clone();
+    let trigger_flag_clone = trigger_flag.clone();
     let trigger_index_clone = trigger_index.clone();
+
+    let trigger_flag_system_tray_clone = trigger_flag.clone();
+    let trigger_index_system_tray_clone = trigger_index.clone();
+
+    let trigger_flag_listen_clone = trigger_flag.clone();
+    let trigger_index_listen_clone = trigger_index.clone();
+
+    let exit_flag_listen_clone = exit_flag.clone();
 
     let rt = Arc::new(Runtime::new().unwrap());
     let rt_clone = Arc::clone(&rt);
@@ -121,7 +126,7 @@ fn main() {
                     rt_clone.clone(),
                     exit_flag_listen_clone.clone(),
                     pressed_keys_clone.clone(),
-                    trigger_index_clone.clone(),
+                    trigger_index_listen_clone.clone(),
                 );
             }
         })
@@ -136,7 +141,15 @@ fn main() {
                 .get_item("settings_location")
                 .set_title(path)
                 .unwrap();
-            let _ = settings::load_settings(app.app_handle());
+
+            let trigger_index_clone = trigger_index_clone.clone();
+            let trigger_flag_second_clone = trigger_flag_clone.clone();
+
+            let _ = settings::load_settings(
+                app.app_handle(),
+                trigger_index_clone.clone(),
+                trigger_flag_second_clone.clone()
+            );
 
             #[cfg(target_os = "macos")]
             {
@@ -147,25 +160,6 @@ fn main() {
             {
                 app_handle.lock().unwrap().replace(app.handle().clone());
             }
-
-            let triggers_clone = {
-                let settings = SETTINGS.lock().unwrap();
-                settings.triggers.clone()
-            };
-
-            for (i, trigger) in triggers_clone.iter().enumerate() {
-                if let Some(shortcut) = trigger.trigger_with_shortcut.clone() {
-                    let trigger_index_clone = trigger_index.clone();
-                    let trigger_flag_second_clone = trigger_flag_clone.clone();
-
-                    app.global_shortcut_manager()
-                        .register(&shortcut, move || {
-                            trigger_index_clone.store(i, Ordering::SeqCst);
-                            trigger_flag_second_clone.store(true, Ordering::SeqCst);
-                        })
-                        .expect("Failed to register global shortcut");
-                }
-            }
             Ok(())
         })
         .system_tray(make_tray())
@@ -175,9 +169,16 @@ fn main() {
                     match id.as_str() {
                         "quit" => std::process::exit(0),
                         "load_settings" => {
-                            settings::load_settings(app.app_handle().clone())
-                                .expect("Failed to load settings.");
-                        }
+                            let trigger_index_clone = trigger_index_system_tray_clone.clone();
+                            let trigger_flag_second_clone = trigger_flag_system_tray_clone.clone();
+
+                            settings::load_settings(
+                                app.app_handle().clone(),
+                                trigger_index_clone.clone(),
+                                trigger_flag_second_clone.clone()
+                            )
+                                .expect("Failed to load settings.")
+                        },
                         _ => {}
                     }
                 }
@@ -222,6 +223,8 @@ fn handle_selection(selection_action: SelectionAction) {
             enigo.key(Key::Backspace, Direction::Click).unwrap();
             // enigo.key(Key::RightArrow, Direction::Click).unwrap();
             // enigo.text("\n\n").unwrap();
+        }
+        SelectionAction::Nothing => {
         }
     }
 }
@@ -326,6 +329,7 @@ fn trigger_action(
 
                 {
                     while let Some(response) = response_stream.next().await {
+
                         let delta_output = {
                             if delta_buffer.len() > 4 && !response.starts_with('\n')
                             // workaround for a bug in enigo, it doesn't like leading newlines

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -336,13 +336,10 @@ fn trigger_action(
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
                                 // Split the output on new lines and send each part followed by an 'Enter' keypress.
-                                for (index, line) in delta_output.split('\n').enumerate() {
-                                    if index != 0 {
-                                        // Simulate pressing the 'Enter' key.
-                                        enigo.key(Key::Return, Direction::Click);
+                                for step in trigger.next_steps.clone() {
+                                    if let Step::StreamTextToScreen = step {
+                                        enigo.text(&delta_output).expect("Failed to type out text");
                                     }
-
-                                    enigo.text(line);
                                 }
                             }
                         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -328,25 +328,33 @@ fn trigger_action(
                     while let Some(response) = response_stream.next().await {
                         whole_buffer.push(response.clone());
                         delta_buffer.push(response);
-
-                        // Changed part: This now simply adds response to the delta_output without the length check.
-                        let delta_output = delta_buffer.clone().join("");
+                    
+                        // No need to clone delta_buffer as we're going to clear it anyway.
+                        let delta_output = delta_buffer.join("");
                         delta_buffer.clear();
-                        
+                    
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
-                                enigo.text(&delta_output).expect("Failed to type out text");
+                                // Split the output on new lines and send each part followed by an 'Enter' keypress.
+                                for (index, line) in delta_output.split('\n').enumerate() {
+                                    if index != 0 {
+                                        // Simulate pressing the 'Enter' key.
+                                        enigo.key(Key::Return, Direction::Click);  
+                                    }
+
+                                    enigo.text(line);
+                                }
                             }
                         }
-
+                    
                         // Exit loop if child process has finished or exit flag is set
                         if exit_flag_thread.load(Ordering::SeqCst) {
                             did_exit = true;
                             break;
                         }
-                    }
+                    }   
                 }
-
+                
                 let mut should_continue = false;
                 if !did_exit {
                     let delta_output = delta_buffer.join("");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -325,24 +325,35 @@ fn trigger_action(
                 let mut did_exit = false;
 
                 {
-                    while let Some(response) = response_stream.next().await {
-                        whole_buffer.push(response.clone());
-                        delta_buffer.push(response);
+                    {
+                        while let Some(response) = response_stream.next().await {
+                            let delta_output = {
+                                if delta_buffer.len() > 4 && !response.starts_with('\n')
+                                // workaround for a bug in enigo, it doesn't like leading newlines
+                                {
+                                    let s = delta_buffer.clone().join("");
+                                    delta_buffer.clear();
+                                    s
+                                } else {
+                                    "".to_string()
+                                }
+                            };
 
-                        // No need to clone delta_buffer as we're going to clear it anyway.
-                        let delta_output = delta_buffer.join("");
-                        delta_buffer.clear();
+                            // move this to after the delta_output so we can not start a delta_buffer with a newline
+                            whole_buffer.push(response.clone());
+                            delta_buffer.push(response);
 
-                        for step in trigger.next_steps.clone() {
-                            if let Step::StreamTextToScreen = step {
-                                enigo.text(&delta_output).expect("Failed to type out text");
+                            for step in trigger.next_steps.clone() {
+                                if let Step::StreamTextToScreen = step {
+                                    enigo.text(&delta_output).expect("Failed to type out text");
+                                }
                             }
-                        }
 
-                        // Exit loop if child process has finished or exit flag is set
-                        if exit_flag_thread.load(Ordering::SeqCst) {
-                            did_exit = true;
-                            break;
+                            // Exit loop if child process has finished or exit flag is set
+                            if exit_flag_thread.load(Ordering::SeqCst) {
+                                did_exit = true;
+                                break;
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -329,16 +329,10 @@ fn trigger_action(
                         whole_buffer.push(response.clone());
                         delta_buffer.push(response);
 
-                        let delta_output = {
-                            if delta_buffer.len() > 4 {
-                                let s = delta_buffer.clone().join("");
-                                delta_buffer.clear();
-                                s
-                            } else {
-                                "".to_string()
-                            }
-                        };
-
+                        // Changed part: This now simply adds response to the delta_output without the length check.
+                        let delta_output = delta_buffer.clone().join("");
+                        delta_buffer.clear();
+                        
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
                                 enigo.text(&delta_output).expect("Failed to type out text");


### PR DESCRIPTION
This is a workaround for an issue with enigo with strings that start with newline (maybe macos only?)

I made sure it never passes a string to enigo.text("\nbad") that started with a newline