### PR TITLE
Issue10 generation skipping some characters

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -328,33 +328,33 @@ fn trigger_action(
                     while let Some(response) = response_stream.next().await {
                         whole_buffer.push(response.clone());
                         delta_buffer.push(response);
-                    
+
                         // No need to clone delta_buffer as we're going to clear it anyway.
                         let delta_output = delta_buffer.join("");
                         delta_buffer.clear();
-                    
+
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
                                 // Split the output on new lines and send each part followed by an 'Enter' keypress.
                                 for (index, line) in delta_output.split('\n').enumerate() {
                                     if index != 0 {
                                         // Simulate pressing the 'Enter' key.
-                                        enigo.key(Key::Return, Direction::Click);  
+                                        enigo.key(Key::Return, Direction::Click);
                                     }
 
                                     enigo.text(line);
                                 }
                             }
                         }
-                    
+
                         // Exit loop if child process has finished or exit flag is set
                         if exit_flag_thread.load(Ordering::SeqCst) {
                             did_exit = true;
                             break;
                         }
-                    }   
+                    }
                 }
-                
+
                 let mut should_continue = false;
                 if !did_exit {
                     let delta_output = delta_buffer.join("");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -335,12 +335,7 @@ fn trigger_action(
 
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
-                                // Split the output on new lines and send each part followed by an 'Enter' keypress.
-                                for step in trigger.next_steps.clone() {
-                                    if let Step::StreamTextToScreen = step {
-                                        enigo.text(&delta_output).expect("Failed to type out text");
-                                    }
-                                }
+                                enigo.text(&delta_output).expect("Failed to type out text");
                             }
                         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -336,13 +336,10 @@ fn trigger_action(
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
                                 // Split the output on new lines and send each part followed by an 'Enter' keypress.
-                                for (index, line) in delta_output.split('\n').enumerate() {
-                                    if index != 0 {
-                                        // Simulate pressing the 'Enter' key.
-                                        enigo.key(Key::Return, Direction::Click);
+                                for step in trigger.next_steps.clone() {
+                                    if let Step::StreamTextToScreen = step {
+                                        enigo.text(&delta_output).expect("Failed to type out text");
                                     }
-
-                                    enigo.text(line);
                                 }
                             }
                         }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -328,25 +328,33 @@ fn trigger_action(
                     while let Some(response) = response_stream.next().await {
                         whole_buffer.push(response.clone());
                         delta_buffer.push(response);
-
-                        // Changed part: This now simply adds response to the delta_output without the length check.
-                        let delta_output = delta_buffer.clone().join("");
+                    
+                        // No need to clone delta_buffer as we're going to clear it anyway.
+                        let delta_output = delta_buffer.join("");
                         delta_buffer.clear();
-                        
+                    
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
-                                enigo.text(&delta_output).expect("Failed to type out text");
+                                // Split the output on new lines and send each part followed by an 'Enter' keypress.
+                                for (index, line) in delta_output.split('\n').enumerate() {
+                                    if index != 0 {
+                                        // Simulate pressing the 'Enter' key.
+                                        enigo.key(Key::Return, Direction::Click);  
+                                    }
+
+                                    enigo.text(line);
+                                }
                             }
                         }
-
+                    
                         // Exit loop if child process has finished or exit flag is set
                         if exit_flag_thread.load(Ordering::SeqCst) {
                             did_exit = true;
                             break;
                         }
-                    }
+                    }   
                 }
-
+                
                 let mut should_continue = false;
                 if !did_exit {
                     let delta_output = delta_buffer.join("");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -325,24 +325,35 @@ fn trigger_action(
                 let mut did_exit = false;
 
                 {
-                    while let Some(response) = response_stream.next().await {
-                        whole_buffer.push(response.clone());
-                        delta_buffer.push(response);
+                    {
+                        while let Some(response) = response_stream.next().await {
+                            let delta_output = {
+                                if delta_buffer.len() > 4 && !response.starts_with('\n')
+                                // workaround for a bug in enigo, it doesn't like leading newlines
+                                {
+                                    let s = delta_buffer.clone().join("");
+                                    delta_buffer.clear();
+                                    s
+                                } else {
+                                    "".to_string()
+                                }
+                            };
 
-                        // No need to clone delta_buffer as we're going to clear it anyway.
-                        let delta_output = delta_buffer.join("");
-                        delta_buffer.clear();
+                            // move this to after the delta_output so we can not start a delta_buffer with a newline
+                            whole_buffer.push(response.clone());
+                            delta_buffer.push(response);
 
-                        for step in trigger.next_steps.clone() {
-                            if let Step::StreamTextToScreen = step {
-                                enigo.text(&delta_output).expect("Failed to type out text");
+                            for step in trigger.next_steps.clone() {
+                                if let Step::StreamTextToScreen = step {
+                                    enigo.text(&delta_output).expect("Failed to type out text");
+                                }
                             }
-                        }
 
-                        // Exit loop if child process has finished or exit flag is set
-                        if exit_flag_thread.load(Ordering::SeqCst) {
-                            did_exit = true;
-                            break;
+                            // Exit loop if child process has finished or exit flag is set
+                            if exit_flag_thread.load(Ordering::SeqCst) {
+                                did_exit = true;
+                                break;
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -329,16 +329,10 @@ fn trigger_action(
                         whole_buffer.push(response.clone());
                         delta_buffer.push(response);
 
-                        let delta_output = {
-                            if delta_buffer.len() > 4 {
-                                let s = delta_buffer.clone().join("");
-                                delta_buffer.clear();
-                                s
-                            } else {
-                                "".to_string()
-                            }
-                        };
-
+                        // Changed part: This now simply adds response to the delta_output without the length check.
+                        let delta_output = delta_buffer.clone().join("");
+                        delta_buffer.clear();
+                        
                         for step in trigger.next_steps.clone() {
                             if let Step::StreamTextToScreen = step {
                                 enigo.text(&delta_output).expect("Failed to type out text");


### PR DESCRIPTION
This is a workaround for an issue with enigo with strings that start with newline (maybe macos only?)

I made sure it never passes a string to enigo.text("\nbad") that started with a newline